### PR TITLE
Bump bootstrap from 3.2.0 to 3.4.1 in /Samples/Source

### DIFF
--- a/Samples/Source/packages.config
+++ b/Samples/Source/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="bootstrap" version="3.2.0" targetFramework="net45" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net45" />
   <package id="jQuery" version="1.9.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Bumps bootstrap from 3.2.0 to 3.4.1.

Signed-off-by: dependabot[bot] <support@github.com>